### PR TITLE
use actual named exports

### DIFF
--- a/lib/data-factory.js
+++ b/lib/data-factory.js
@@ -5,42 +5,40 @@ import { NamedNode } from './named-node'
 import { Quad } from './quad'
 import { Variable } from './variable'
 
-export function DataFactory () {}
+export const defaultGraphInstance = new DefaultGraph()
 
-DataFactory.namedNode = function (value) {
+export function namedNode (value) {
   return new NamedNode(value)
 }
 
-DataFactory.blankNode = function (value) {
+export function blankNode (value) {
   return new BlankNode(value)
 }
 
-DataFactory.literal = function (value, languageOrDatatype) {
+export function literal (value, languageOrDatatype) {
   if (typeof languageOrDatatype === 'string') {
     if (languageOrDatatype.indexOf(':') === -1) {
       return new Literal(value, languageOrDatatype)
     }
 
-    return new Literal(value, null, DataFactory.namedNode(languageOrDatatype))
+    return new Literal(value, null, namedNode(languageOrDatatype))
   }
 
   return new Literal(value, null, languageOrDatatype)
 }
 
-DataFactory.defaultGraph = function () {
-  return DataFactory.defaultGraphInstance
+export function defaultGraph () {
+  return defaultGraphInstance
 }
 
-DataFactory.variable = function (value) {
+export function variable (value) {
   return new Variable(value)
 }
 
-DataFactory.triple = function (subject, predicate, object) {
-  return DataFactory.quad(subject, predicate, object)
+export function quad (subject, predicate, object, graph) {
+  return new Quad(subject, predicate, object, graph || defaultGraphInstance)
 }
 
-DataFactory.quad = function (subject, predicate, object, graph) {
-  return new Quad(subject, predicate, object, graph || DataFactory.defaultGraphInstance)
+export function triple (subject, predicate, object) {
+  return quad(subject, predicate, object)
 }
-
-DataFactory.defaultGraphInstance = new DefaultGraph()

--- a/main.js
+++ b/main.js
@@ -1,1 +1,1 @@
-export { DataFactory } from './lib/data-factory'
+export * from './lib/data-factory'

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,4 @@
-import { DataFactory } from '../index.js'
+import * as DataFactory from '../index.js'
 import { runTests } from './index.js'
 
 runTests(DataFactory)


### PR DESCRIPTION
I suggests that we ditch the awkward `function DataFactory() {}` and replace the entire thing with named exports.

Import as "DataFactory"

```js
import * as RDF from '@rdfjs/data-model'
```

Or individually as you often would

```js
import { namedNode, blankNode } from '@rdfjs/data-model'
```

In node nothing changes

```js
const DataFactory = require('@rdfjs/data-model')
const { namedNode } = require('@rdfjs/data-model')
```